### PR TITLE
fix: Fix behavior when reading from static source

### DIFF
--- a/src/tool.py
+++ b/src/tool.py
@@ -183,7 +183,7 @@ class CopickTool(ToolInstance):
 
     def store(self):
         for pick, pl in self.picks_map.items():
-            if pick.from_tool:
+            if pick.from_tool or pick.read_only:
                 continue
 
             points = []
@@ -318,7 +318,7 @@ class CopickTool(ToolInstance):
                 volume = None
 
         # Have to call this now to set before OPTIONS_PARTLIST_CHANGED is triggered
-        partlist.editing_locked = picks.from_tool
+        partlist.editing_locked = picks.from_tool or picks.read_only
 
         self.session.ArtiaX.add_particlelist(partlist)
 
@@ -345,7 +345,7 @@ class CopickTool(ToolInstance):
             partlist.hide_markers()
             partlist.hide_axes()
 
-        if picks.from_tool:
+        if picks.from_tool or picks.read_only:
             lock_particlelist([partlist], True, "all", True)
 
         run(self.session, "artiax cap true", log=False)

--- a/src/ui/QUnifiedTable.py
+++ b/src/ui/QUnifiedTable.py
@@ -291,7 +291,7 @@ class QUnifiedTable(QWidget):
             source_index = self._filter_model.mapToSource(proxy_index) if self._filter_model else proxy_index
 
             entity = self._source_model.get_entity(source_index)
-            if entity and not getattr(entity, "from_tool", False):
+            if entity and not (entity.from_tool or entity.read_only):
                 can_delete = True
 
         self._delete_button.setEnabled(can_delete)

--- a/src/ui/QUnifiedTableModel.py
+++ b/src/ui/QUnifiedTableModel.py
@@ -85,7 +85,7 @@ class QUnifiedTableModel(QAbstractTableModel):
         if role == Qt.DisplayRole:
             if column == 0:
                 # Show user/tool name with lock/unlock indicator
-                access_indicator = "🔒" if entity.entity.from_tool else "✏️"
+                access_indicator = "🔒" if (entity.entity.from_tool or entity.entity.read_only) else "✏️"
                 return f"{access_indicator} {entity.data(0)}"
             elif column == 1:
                 return entity.data(1)
@@ -106,7 +106,7 @@ class QUnifiedTableModel(QAbstractTableModel):
 
         elif role == Qt.ToolTipRole:
             if column == 0:
-                if entity.entity.from_tool:
+                if entity.entity.from_tool or entity.entity.read_only:
                     return f"Tool-generated entity (read-only): {entity.data(0)}"
                 else:
                     return f"User-generated entity (editable): {entity.data(0)}"


### PR DESCRIPTION
Regression introduced by only checking `from_tool` and not `read_only`. Fixes behavior with read_only source.