### PR TITLE
chore: establish ChimeraX migration gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Migration tests
+
+on:
+  push:
+    branches: [main, v2.0]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  portable:
+    name: Portable seam (Python 3.14)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          version: "0.12.4"
+
+      - name: Verify interpreter
+        run: >
+          uv run --python 3.14 --no-project python -c
+          "import sys; assert sys.version_info[:2] == (3, 14), sys.version;
+          assert sys.version_info.releaselevel == 'final', sys.version"
+
+      - name: Run portable tests
+        run: >
+          uv run --python 3.14 --no-project --with pytest==9.1.1 --with "numpy>=2.0.2"
+          python -m pytest -q -m "not chimerax and not integration"
+
+      - name: Check migration Python
+        run: |
+          uvx --from ruff==0.16.3 ruff check --select E9,F63,F7,F82 src tests scripts
+          uvx --from ruff==0.16.3 ruff format --check tests scripts
+          python -m compileall -q src tests scripts

--- a/docs/release-alpha.md
+++ b/docs/release-alpha.md
@@ -1,0 +1,55 @@
+# chimerax-copick 2.0 alpha release runbook
+
+Alpha bundles are GitHub prereleases only. Do not submit an alpha to the public ChimeraX Toolshed.
+
+## Fixed initial inputs
+
+- `copick==2.0.0a1`
+- `copick-shared-ui==2.0.0a1`; wheel SHA-256
+  `c56d06ee53cffc7cda56a916d480793198e2311b099e7965c132ea27e43f6515`
+- `ChimeraX-OME-Zarr==1.0.0a1`; wheel SHA-256
+  `fd9f0c49505237d200c65afafb24a088ee1f7eb8f8ab29e84991a358354684b0`
+- `zarr==3.1.6` for the minimum-stack run
+- ChimeraX Daily 1.13 with Core `>=1.13.dev202608172052` and embedded Python 3.14
+
+These versions and hashes are the release record for the initial alpha stack. Change them only after the complete
+downstream matrix passes with a later published artifact.
+
+## Build the tagged source
+
+1. Merge the Release Please PR for `v2.0` only after its version is exactly `2.0.0-alpha.N` and its release is
+   marked as a GitHub prerelease.
+2. Check out the resulting tag in a clean worktree and record `git rev-parse HEAD`.
+3. In ChimeraX Daily 1.13, run `devel build <checkout>`.
+4. Locate the single generated wheel under `<checkout>/dist/` and calculate `shasum -a 256 <wheel>`.
+5. Run `python scripts/inspect_bundle.py <wheel> --expected-version 2.0.0aN` with the `packaging` library
+   available. Record its output.
+
+Generic `uv build` is not a supported bundle build: ChimeraX's bundle builder supplies the dynamic classifier
+metadata. The Python floor is static in `pyproject.toml` so the pure-Python bundle keeps `Requires-Python: >=3.14`
+instead of the builder's generic ChimeraX 1.0 floor.
+
+## Install and validate in an isolated Daily profile
+
+Use a new ChimeraX user profile reserved for this release candidate. Download
+`chimerax_ome_zarr-1.0.0a1-py3-none-any.whl` from its `v1.0.0-alpha.1` GitHub release and verify its SHA-256 against
+the value under **Fixed initial inputs** above. Install that wheel first with ChimeraX `toolshed install`. Install the
+chimerax-copick wheel second with dependency resolution enabled; confirm the resolver selects the exact copick and
+shared-UI alphas above.
+
+Run `scripts/installed_bundle_smoke.py` with the embedded Python, then start the Copick tool and verify every
+registered `copick` command is discoverable. Execute the native, local-fixture, backend, and gallery/worker gates
+from Epic #85 and retain their logs with:
+
+- ChimeraX/Core and embedded Python versions;
+- every package version printed by the installed-bundle smoke;
+- upstream and chimerax-copick wheel SHA-256 values;
+- the exact Git tag and commit; and
+- named results for local, S3-compatible, Secure Shell, ML Croissant, portal, and optional SMB coverage.
+
+## Attach and roll back
+
+Attach only the wheel and a matching `.sha256` file that passed the installed-artifact matrix to the GitHub
+prerelease. If any required gate fails, leave the prerelease clearly marked as unqualified (or remove the broken
+asset), uninstall the candidate from the isolated profile, and discard that profile. Fixes use the next
+`2.0.0-alpha.N`; never replace a previously published artifact under the same version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = ["setuptools>=45"]
 
 [project]
 name = "ChimeraX-copick"
-dynamic = ["version", "classifiers", "requires-python"]
+dynamic = ["version", "classifiers"]
+requires-python = ">=3.14"
 dependencies = [
     "ChimeraX-Core>=1.7",
     "ChimeraX-ArtiaX>=0.7.0",
@@ -36,6 +37,17 @@ dev = [
     "ipython",
     "pre-commit",
     "ruff",
+]
+testing = [
+    "pytest>=9.1.1,<10",
+]
+
+[tool.pytest.ini_options]
+addopts = "--strict-config --strict-markers"
+testpaths = ["tests"]
+markers = [
+    "chimerax: requires a native ChimeraX Daily runtime",
+    "integration: requires published artifacts or an external storage service",
 ]
 
 [chimerax]

--- a/scripts/inspect_bundle.py
+++ b/scripts/inspect_bundle.py
@@ -1,0 +1,70 @@
+"""Inspect release-wheel metadata without importing the ChimeraX bundle."""
+
+from __future__ import annotations
+
+import argparse
+import email
+import sys
+import zipfile
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+
+EXPECTED_REQUIREMENTS = {
+    "chimerax-core": ">=1.13.dev202608172052",
+    "chimerax-ome-zarr": ">=1.0.0a1,<2",
+    "copick": ">=2.0.0a1,<3",
+    "copick-shared-ui": ">=2.0.0a1,<3",
+    "numpy": ">=2.0.2",
+}
+FORBIDDEN_DIRECT_REQUIREMENTS = {"aiohttp", "hatchling", "pydantic", "s3fs"}
+
+
+def inspect_wheel(path: Path, expected_version: str | None) -> None:
+    with zipfile.ZipFile(path) as archive:
+        metadata_files = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+        if len(metadata_files) != 1:
+            raise ValueError(f"expected one METADATA file, found {metadata_files}")
+        metadata = email.message_from_bytes(archive.read(metadata_files[0]))
+
+    if canonicalize_name(metadata["Name"]) != "chimerax-copick":
+        raise ValueError(f"unexpected distribution name: {metadata['Name']}")
+    if expected_version is not None and Version(metadata["Version"]) != Version(expected_version):
+        raise ValueError(f"expected version {expected_version}, found {metadata['Version']}")
+    if metadata["Requires-Python"] != ">=3.14":
+        raise ValueError(f"expected Requires-Python >=3.14, found {metadata['Requires-Python']}")
+
+    requirements = {
+        canonicalize_name(requirement.name): requirement
+        for requirement in map(Requirement, metadata.get_all("Requires-Dist", []))
+        if requirement.marker is None or "extra" not in str(requirement.marker)
+    }
+    for name, specifier in EXPECTED_REQUIREMENTS.items():
+        requirement = requirements.get(name)
+        if requirement is None or str(requirement.specifier) != specifier:
+            raise ValueError(f"expected {name}{specifier}, found {requirement}")
+    unexpected = FORBIDDEN_DIRECT_REQUIREMENTS.intersection(requirements)
+    if unexpected:
+        raise ValueError(f"unexpected direct runtime requirements: {sorted(unexpected)}")
+
+    print(f"validated {path.name}: chimerax-copick {metadata['Version']}, Python {metadata['Requires-Python']}")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel", type=Path)
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args(argv)
+    try:
+        inspect_wheel(arguments.wheel, arguments.expected_version)
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/installed_bundle_smoke.py
+++ b/scripts/installed_bundle_smoke.py
@@ -1,0 +1,25 @@
+"""Run from ChimeraX's Python after installing an exact release wheel."""
+
+import importlib.metadata
+import json
+import platform
+
+import chimerax.copick
+from chimerax.copick import tool
+
+
+packages = [
+    "ChimeraX-copick",
+    "ChimeraX-Core",
+    "ChimeraX-OME-Zarr",
+    "copick",
+    "copick-shared-ui",
+    "zarr",
+    "numcodecs",
+    "fsspec",
+]
+versions = {name: importlib.metadata.version(name) for name in packages}
+
+assert chimerax.copick.bundle_api is not None
+assert tool.CopickTool.help == "help:user/tools/copick.html"
+print(json.dumps({"python": platform.python_version(), "packages": versions}, indent=2, sort_keys=True))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Narrow stubs for testing bundle logic outside ChimeraX."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPOSITORY_ROOT / "src"
+
+
+class Placeholder:
+    """Import-compatible stand-in for ChimeraX, ArtiaX, Qt, and copick types."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _module(monkeypatch, name: str, **attributes) -> ModuleType:
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+@pytest.fixture
+def tool_module(monkeypatch):
+    """Load ``src/tool.py`` with only its import-time host APIs stubbed."""
+
+    for package in (
+        "chimerax",
+        "chimerax.artiax",
+        "chimerax.artiax.io",
+        "chimerax.artiax.particle",
+        "chimerax.core",
+        "chimerax.ome_zarr",
+        "copick.impl",
+        "copick.util",
+        "copick_shared_ui",
+        "copick_shared_ui.core",
+        "Qt",
+    ):
+        _module(monkeypatch, package)
+
+    _module(monkeypatch, "copick")
+    _module(monkeypatch, "chimerax.artiax.ArtiaX", OPTIONS_PARTLIST_CHANGED="options changed")
+    _module(monkeypatch, "chimerax.artiax.io.formats", get_formats=lambda _session: {})
+    _module(
+        monkeypatch,
+        "chimerax.artiax.particle.ParticleList",
+        PARTLIST_CHANGED="particle list changed",
+        ParticleList=Placeholder,
+        lock_particlelist=lambda *_args, **_kwargs: None,
+    )
+    _module(
+        monkeypatch,
+        "chimerax.core.commands",
+        log_equivalent_command=lambda *_args, **_kwargs: None,
+        run=lambda *_args, **_kwargs: None,
+    )
+    _module(monkeypatch, "chimerax.core.models", Surface=Placeholder)
+    _module(monkeypatch, "chimerax.core.tools", ToolInstance=Placeholder)
+    _module(
+        monkeypatch,
+        "chimerax.ome_zarr.open",
+        open_ome_zarr_from_store=lambda *_args, **_kwargs: ([], ""),
+    )
+    _module(monkeypatch, "chimerax.ui", MainToolWindow=Placeholder)
+    _module(monkeypatch, "copick.impl.filesystem", CopickTomogramFSSpec=Placeholder)
+    _module(
+        monkeypatch,
+        "copick.models",
+        CopickLocation=Placeholder,
+        CopickMesh=Placeholder,
+        CopickPicks=Placeholder,
+        CopickPoint=Placeholder,
+        CopickSegmentation=Placeholder,
+    )
+    _module(monkeypatch, "copick.util.uri", serialize_copick_uri=lambda entity: str(entity))
+    _module(
+        monkeypatch,
+        "copick_shared_ui.core.thumbnail_cache",
+        set_global_cache_config=lambda *_args, **_kwargs: None,
+        set_global_cache_image_interface=lambda *_args, **_kwargs: None,
+    )
+    _module(monkeypatch, "Qt.QtCore", QModelIndex=Placeholder)
+    _module(monkeypatch, "Qt.QtGui", QFont=Placeholder)
+    _module(monkeypatch, "Qt.QtWidgets", QVBoxLayout=Placeholder)
+
+    bundle_package = _module(monkeypatch, "portable_bundle")
+    bundle_package.__path__ = [str(SOURCE_ROOT)]
+    _module(monkeypatch, "portable_bundle.misc.colorops", palette_from_root=lambda _root: "")
+    _module(monkeypatch, "portable_bundle.misc.meshops", ensure_mesh=lambda mesh: mesh)
+    _module(monkeypatch, "portable_bundle.misc.pickops", append_no_duplicates=lambda left, _right: left)
+    _module(monkeypatch, "portable_bundle.misc.settings", CoPickSettings=Placeholder)
+    _module(monkeypatch, "portable_bundle.ui.EntityTable", TablePicks=Placeholder)
+    _module(monkeypatch, "portable_bundle.ui.main_widget", MainWidget=Placeholder)
+    _module(monkeypatch, "portable_bundle.ui.tree", TreeTomogram=Placeholder)
+
+    spec = importlib.util.spec_from_file_location("portable_bundle.tool", SOURCE_ROOT / "tool.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_native_chimerax.py
+++ b/tests/test_native_chimerax.py
@@ -1,0 +1,14 @@
+"""Native smoke collected only inside ChimeraX Daily release-gate runs."""
+
+import pytest
+
+
+pytestmark = pytest.mark.chimerax
+
+
+def test_bundle_imports_inside_chimerax():
+    import chimerax.copick
+    from chimerax.copick import tool
+
+    assert chimerax.copick.bundle_api is not None
+    assert tool.CopickTool.help == "help:user/tools/copick.html"

--- a/tests/test_portable_seam.py
+++ b/tests/test_portable_seam.py
@@ -1,0 +1,14 @@
+"""Portable baseline for logic that does not require a ChimeraX process."""
+
+
+def test_build_command_preserves_public_command_shape(tool_module):
+    command = tool_module.build_command(
+        "copick open run",
+        "run-1",
+        None,
+        tomo_type="wbp",
+        user_label="label with spaces",
+        absent=None,
+    )
+
+    assert command == "copick open run run-1 tomo_type wbp user_label 'label with spaces'"


### PR DESCRIPTION
## Summary

- add the portable ChimeraX/ArtiaX seam and a separately marked native ChimeraX smoke
- declare `requires-python = ">=3.14"` statically so the pure-Python ChimeraX builder does not emit its generic `>=3.7` floor
- make both CI interpreter verification and pytest select Python 3.14 explicitly through `uv --python 3.14`
- record exact initial alpha versions and upstream wheel hashes directly in the release runbook
- add bundle inspection, installed-bundle smoke, and the tagged alpha build/install/rollback runbook

The `v2.0` base already contains the independent Release Please alpha configuration and its `Release-As: 2.0.0-alpha.1` bootstrap footer. Alpha bundles remain GitHub prereleases and are not submitted to the public ChimeraX Toolshed.

## Stack

Layer 1 of 4. Targets `v2.0`; the next layer is `uermel/zarr-v3-x1-alpha-stack`.

## Validation

- portable Python 3.14 seam passes
- the completed stack builds with ChimeraX Daily 1.13 and emits `Requires-Python: >=3.14`
- `inspect_bundle.py` accepts that generated wheel
- all workflow files pass action-validator
- source, tests, and scripts compile
- native installed-bundle validation remains an explicit release gate

Part of #86
Part of #85
