### PR TITLE
feat!: adopt the copick 2.0 alpha stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,12 @@ name = "ChimeraX-copick"
 dynamic = ["version", "classifiers"]
 requires-python = ">=3.14"
 dependencies = [
-    "ChimeraX-Core>=1.7",
+    "ChimeraX-Core>=1.13.dev202608172052",
     "ChimeraX-ArtiaX>=0.7.0",
-    "ChimeraX-OME-Zarr>=0.5.4",
-    "pydantic",
-    "hatchling",
-    "aiohttp>=3.13.0",
-    "s3fs>=2024.3.1",
-    "copick[all]>=1.25.3",
-    "copick-shared-ui>=0.6.0",
+    "ChimeraX-OME-Zarr>=1.0.0a1,<2",
+    "copick[all]>=2.0.0a1,<3",
+    "copick-shared-ui>=2.0.0a1,<3",
+    "numpy>=2.0.2",
 ]
 authors = [
   {name = "Utz H. Ermel", email = "utz@ermel.me"},

--- a/scripts/inspect_bundle.py
+++ b/scripts/inspect_bundle.py
@@ -9,6 +9,7 @@ import zipfile
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
@@ -44,7 +45,7 @@ def inspect_wheel(path: Path, expected_version: str | None) -> None:
     }
     for name, specifier in EXPECTED_REQUIREMENTS.items():
         requirement = requirements.get(name)
-        if requirement is None or str(requirement.specifier) != specifier:
+        if requirement is None or requirement.specifier != SpecifierSet(specifier):
             raise ValueError(f"expected {name}{specifier}, found {requirement}")
     unexpected = FORBIDDEN_DIRECT_REQUIREMENTS.intersection(requirements)
     if unexpected:

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,0 +1,28 @@
+"""Application-level contracts for passing copick stores to the viewer."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class DensityMapObject(Protocol):
+    """The public copick object surface used by chimerax-copick."""
+
+    name: str
+
+    def has_density_map(self) -> bool: ...
+
+    def zarr(self) -> Any | None: ...
+
+
+def density_map_store(pickable_object: DensityMapObject) -> Any | None:
+    """Return one density-map store, using copick's explicit existence contract."""
+
+    if not pickable_object.has_density_map():
+        return None
+
+    store = pickable_object.zarr()
+    if store is None:
+        name = getattr(pickable_object, "name", "<unknown>")
+        raise RuntimeError(f"Copick object {name!r} reports a density map but returned no store")
+    return store

--- a/src/tool.py
+++ b/src/tool.py
@@ -39,6 +39,7 @@ from .misc.colorops import palette_from_root
 from .misc.meshops import ensure_mesh
 from .misc.pickops import append_no_duplicates
 from .misc.settings import CoPickSettings
+from .storage import density_map_store
 
 # from .ui.pickstable import TablePicks
 from .ui.EntityTable import TablePicks
@@ -441,12 +442,11 @@ class CopickTool(ToolInstance):
         if pick_obj is not None:
             partlist.color = np.array(pick_obj.color)
 
-            if pick_obj.zarr() is not None and len(pick_obj.zarr()) > 0:
-                model, msg = open_ome_zarr_from_store(self.session, pick_obj.zarr(), name)
+            store = density_map_store(pick_obj)
+            if store is not None:
+                model, msg = open_ome_zarr_from_store(self.session, store, name)
                 model = model[0]
                 volume = model.child_models()[0]
-            else:
-                volume = None
 
         # Have to call this now to set before OPTIONS_PARTLIST_CHANGED is triggered
         partlist.editing_locked = picks.from_tool or picks.read_only

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def tool_module(monkeypatch):
     )
     _module(monkeypatch, "chimerax.core.models", Surface=Placeholder)
     _module(monkeypatch, "chimerax.core.tools", ToolInstance=Placeholder)
+    _module(monkeypatch, "chimerax.geometry", Place=Placeholder, translation=lambda value: value)
     _module(
         monkeypatch,
         "chimerax.ome_zarr.open",

--- a/tests/test_density_map_contract.py
+++ b/tests/test_density_map_contract.py
@@ -1,0 +1,145 @@
+"""Consumer tests for the copick 2.0 density-map store contract."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class PickableObject:
+    name = "ribosome"
+    color = [10, 20, 30, 255]
+    radius = 42
+    map_threshold = 0.6
+
+    def __init__(self, *, exists, store):
+        self.exists = exists
+        self.store = store
+        self.has_density_map_calls = 0
+        self.zarr_calls = 0
+
+    def has_density_map(self):
+        self.has_density_map_calls += 1
+        return self.exists
+
+    def zarr(self):
+        self.zarr_calls += 1
+        return self.store
+
+
+class ParticleList:
+    def __init__(self, name, session, data):
+        self.name = name
+        self.session = session
+        self.data = data
+        self.selected_particles = None
+        self.attached = []
+
+    def attach_display_model(self, volume):
+        self.attached.append(volume)
+
+    def hide_surfaces(self):
+        pass
+
+    def show_markers(self):
+        pass
+
+    def show_axes(self):
+        pass
+
+    def hide_markers(self):
+        pass
+
+    def hide_axes(self):
+        pass
+
+
+class ParticleData:
+    def new_particle(self):
+        raise AssertionError("the fixture contains no points")
+
+
+class Entity(SimpleNamespace):
+    __hash__ = object.__hash__
+
+
+def _exercise_particle_load(tool_module, monkeypatch, pickable_object, opener):
+    root = SimpleNamespace(get_object=lambda _name: pickable_object)
+    picks = Entity(
+        run=SimpleNamespace(root=root),
+        pickable_object_name=pickable_object.name,
+        points=[],
+        from_tool=False,
+        read_only=False,
+        trust_orientation=True,
+    )
+    artiax = SimpleNamespace(added=[], add_particlelist=lambda partlist: artiax.added.append(partlist))
+    session = SimpleNamespace(ArtiaX=artiax)
+    tool = tool_module.CopickTool.__new__(tool_module.CopickTool)
+    tool.session = session
+    tool.picks_map = {}
+    tool.update_stepper = lambda _partlist: None
+
+    formats = {"Copick Picks file": SimpleNamespace(particle_data=lambda *_args, **_kwargs: ParticleData())}
+    monkeypatch.setattr(tool_module, "get_formats", lambda _session: formats)
+    monkeypatch.setattr(tool_module, "ParticleList", ParticleList)
+    monkeypatch.setattr(tool_module, "open_ome_zarr_from_store", opener)
+
+    tool.show_particles_from_picks(picks)
+    return artiax.added[0]
+
+
+def test_present_density_map_is_obtained_once_and_passed_unchanged(tool_module, monkeypatch):
+    store = object()
+    pickable_object = PickableObject(exists=True, store=store)
+    volume = SimpleNamespace(region=((0, 0, 0), (9, 9, 9), (2, 2, 2)))
+    model = SimpleNamespace(child_models=lambda: [volume])
+    viewer_calls = []
+
+    def open_store(session, received_store, name):
+        viewer_calls.append((session, received_store, name))
+        return [model], ""
+
+    partlist = _exercise_particle_load(tool_module, monkeypatch, pickable_object, open_store)
+
+    assert pickable_object.has_density_map_calls == 1
+    assert pickable_object.zarr_calls == 1
+    assert viewer_calls[0][1] is store
+    assert viewer_calls[0][2] == "ribosome"
+    assert partlist.attached == [volume]
+    assert volume.region[2] == (1, 1, 1)
+    assert partlist.surface_level == 0.6
+
+
+@pytest.mark.parametrize("is_particle", [False, True])
+def test_object_without_density_map_does_not_open_or_construct_store(tool_module, monkeypatch, is_particle):
+    pickable_object = PickableObject(exists=False, store=object())
+    pickable_object.is_particle = is_particle
+
+    def unexpected_open(*_args):
+        raise AssertionError("viewer must not open an absent density map")
+
+    partlist = _exercise_particle_load(tool_module, monkeypatch, pickable_object, unexpected_open)
+
+    assert pickable_object.has_density_map_calls == 1
+    assert pickable_object.zarr_calls == 0
+    assert partlist.attached == []
+
+
+def test_true_existence_with_none_store_is_a_clear_contract_error(tool_module, monkeypatch):
+    pickable_object = PickableObject(exists=True, store=None)
+
+    with pytest.raises(RuntimeError, match="reports a density map but returned no store"):
+        _exercise_particle_load(tool_module, monkeypatch, pickable_object, lambda *_args: None)
+
+    assert pickable_object.has_density_map_calls == 1
+    assert pickable_object.zarr_calls == 1
+
+
+def test_viewer_failure_is_not_swallowed(tool_module, monkeypatch):
+    pickable_object = PickableObject(exists=True, store=object())
+
+    def fail(*_args):
+        raise PermissionError("backend denied density-map read")
+
+    with pytest.raises(PermissionError, match="backend denied density-map read"):
+        _exercise_particle_load(tool_module, monkeypatch, pickable_object, fail)


### PR DESCRIPTION
## Summary

- require ChimeraX Core 1.13 Daily, ChimeraX-OME-Zarr 1.0 alpha, copick 2.0 alpha, shared UI 2.0 alpha, and NumPy 2
- remove the unused direct pydantic, hatchling, aiohttp, and s3fs runtime declarations
- replace the mapping-style density-map length probe with the public `has_density_map()` contract
- obtain the density-map store once and pass that exact object unchanged to ChimeraX-OME-Zarr
- compare dependency specifiers semantically so reordered wheel metadata such as `ChimeraX-OME-Zarr<2,>=1.0.0a1` is accepted
- preserve no-density-map behavior and surface impossible true/None results clearly

The density-map change fixes more than Zarr v3's incompatible `len(store)` behavior. On a writable `CopickObjectFSSpec`, the former `.zarr()` existence probe could create an empty density-map store because `.zarr()` selects `create = not fs.exists(path)`. Calling `has_density_map()` before obtaining the store removes that latent write side effect.

## Stack

Layer 2 of 4. Targets `uermel/zarr-v3-x0-test-gate`; the next layer is `uermel/zarr-v3-x2-volume-parity`.

## Validation

- focused behavior suite passes on Python 3.14
- present, absent, impossible contract, and viewer-error paths are covered
- the exact returned store identity is preserved and `.zarr()` is called only after existence is confirmed
- release runbook records the selected shared UI and reader versions and wheel hashes

Part of #87
Part of #85
