### PR TITLE
chore: verify Zarr v2 and v3 volume handoff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,12 @@ concurrency:
 
 jobs:
   portable:
-    name: Portable seam (Python 3.14)
+    name: Portable seam (Python 3.14, Zarr ${{ matrix.zarr-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        zarr-version: ["3.1.6", "3.3.0"]
     steps:
       - uses: actions/checkout@v7
 
@@ -35,6 +39,7 @@ jobs:
       - name: Run portable tests
         run: >
           uv run --python 3.14 --no-project --with pytest==9.1.1 --with "numpy>=2.0.2"
+          --with "zarr==${{ matrix.zarr-version }}"
           python -m pytest -q -m "not chimerax and not integration"
 
       - name: Check migration Python

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Portable and native migration tests for chimerax-copick."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,71 @@
+"""Small independent OME-Zarr fixtures for the application consumer seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import zarr
+from zarr.storage import LocalStore
+
+
+def spatial_axes():
+    return [{"name": axis, "type": "space", "unit": "angstrom"} for axis in ("z", "y", "x")]
+
+
+def write_ome_image(
+    path: Path,
+    *,
+    zarr_format: int,
+    paths=("0", "1"),
+    array_options=None,
+):
+    """Write equivalent two-level 0.4/v2 or 0.5/v3 image data."""
+
+    values = (
+        np.arange(4 * 6 * 8, dtype=np.int16).reshape(4, 6, 8),
+        np.arange(2 * 3 * 4, dtype=np.int16).reshape(2, 3, 4),
+    )
+    store = LocalStore(path)
+    group = zarr.group(store=store, zarr_format=zarr_format)
+    options = dict(array_options or {})
+    if zarr_format == 2:
+        options.setdefault("chunks", (1, 2, 2))
+        options.setdefault("compressor", None)
+    else:
+        options.setdefault("chunks", (1, 2, 2))
+        options.setdefault("dimension_names", ("z", "y", "x"))
+
+    for level_path, level_values in zip(paths, values, strict=True):
+        group.create_array(level_path, data=level_values, **options)
+
+    version = "0.4" if zarr_format == 2 else "0.5"
+    multiscales = [
+        {
+            "version": version,
+            "axes": spatial_axes(),
+            "datasets": [
+                {
+                    "path": level_path,
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [10.0 * 2**level, 10.0 * 2**level, 10.0 * 2**level]},
+                    ],
+                }
+                for level, level_path in enumerate(paths)
+            ],
+        },
+    ]
+    if zarr_format == 2:
+        group.attrs["multiscales"] = multiscales
+    else:
+        group.attrs["ome"] = {"version": "0.5", "multiscales": multiscales}
+    return store, values
+
+
+def snapshot(path: Path):
+    return {item.relative_to(path).as_posix(): item.read_bytes() for item in path.rglob("*") if item.is_file()}
+
+
+def first_declared_path(group):
+    attributes = dict(group.attrs)
+    return attributes.get("ome", attributes)["multiscales"][0]["datasets"][0]["path"]

--- a/tests/test_segmentation_handoff.py
+++ b/tests/test_segmentation_handoff.py
@@ -1,0 +1,85 @@
+"""Segmentation model wiring stays independent of its Zarr format."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tests.helpers import snapshot, write_ome_image
+
+
+class Segmentation(SimpleNamespace):
+    __hash__ = object.__hash__
+
+    def zarr(self):
+        self.zarr_calls += 1
+        return self.store
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+@pytest.mark.parametrize("is_multilabel", [False, True])
+def test_segmentation_store_and_display_contract_are_format_independent(
+    tool_module, monkeypatch, tmp_path, zarr_format, is_multilabel
+):
+    path = tmp_path / f"segmentation-{zarr_format}-{is_multilabel}.zarr"
+    store, _values = write_ome_image(path, zarr_format=zarr_format, paths=("seg", "coarse"))
+    before = snapshot(path)
+    pickable_object = SimpleNamespace(color=[100, 110, 120, 255])
+    root = SimpleNamespace(get_object=lambda _name: pickable_object)
+    segmentation = Segmentation(
+        name="ribosome",
+        run=SimpleNamespace(root=root),
+        store=store,
+        zarr_calls=0,
+        is_multilabel=is_multilabel,
+    )
+    child = SimpleNamespace()
+    imported_volume = SimpleNamespace(
+        id_string="17",
+        data=SimpleNamespace(step=(10.0, 10.0, 10.0)),
+        child_models=lambda: [child],
+    )
+    source_volume = SimpleNamespace()
+    model = SimpleNamespace(child_models=lambda: [source_volume])
+    viewer_calls = []
+    commands = []
+
+    def open_store(session, received_store, name):
+        viewer_calls.append((session, received_store, name))
+        return [model], ""
+
+    artiax = SimpleNamespace(import_tomogram=lambda volume: imported_volume, options_tomogram=None)
+    session = SimpleNamespace(
+        ArtiaX=artiax,
+        models=SimpleNamespace(add=lambda _models: None),
+    )
+    tool = tool_module.CopickTool.__new__(tool_module.CopickTool)
+    tool.session = session
+    tool.active_volume = SimpleNamespace(id=7)
+    tool.seg_map = {}
+    tool.palette_command = "red:1,green:2"
+    monkeypatch.setattr(tool_module, "open_ome_zarr_from_store", open_store)
+    monkeypatch.setattr(
+        tool_module,
+        "run",
+        lambda _session, command, **kwargs: commands.append((command, kwargs)),
+    )
+
+    tool.show_volume_from_segmentation(segmentation)
+
+    assert segmentation.zarr_calls == 1
+    assert viewer_calls[0][1] is store
+    assert viewer_calls[0][2] == "ribosome"
+    assert tool.seg_map[segmentation] is imported_volume
+    assert artiax.options_tomogram == 7
+    assert [command for command, _kwargs in commands[:3]] == [
+        "volume #17 style surface",
+        "volume #17 level 0.5",
+        "volume #17 step 1",
+    ]
+    if is_multilabel:
+        assert commands[3][0] == "color sample #17 map #17 palette red:1,green:2 offset -20.0"
+    else:
+        np.testing.assert_array_equal(imported_volume.color, [100, 110, 120, 255])
+        np.testing.assert_array_equal(child.color, [100, 110, 120, 255])
+    assert snapshot(path) == before

--- a/tests/test_volume_handoff.py
+++ b/tests/test_volume_handoff.py
@@ -1,0 +1,116 @@
+"""Application parity at the copick-store to ChimeraX-reader boundary."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import zarr
+from zarr.codecs import GzipCodec, TransposeCodec, ZstdCodec
+
+from tests.helpers import first_declared_path, snapshot, write_ome_image
+
+
+class Tomogram:
+    def __init__(self, store):
+        self.store = store
+        self.zarr_calls = 0
+        self.voxel_spacing = SimpleNamespace(run=SimpleNamespace(name="run-1"), voxel_size=10.0)
+
+    def zarr(self):
+        self.zarr_calls += 1
+        return self.store
+
+
+class RecordingReader:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, session, store, name, **kwargs):
+        group = zarr.open_group(store=store, mode="r")
+        path = first_declared_path(group)
+        volume = SimpleNamespace(
+            decoded=np.asarray(group[path]),
+            declared_path=path,
+            region=((0, 0, 0), tuple(size - 1 for size in group[path].shape), kwargs.get("initial_step")),
+        )
+        model = SimpleNamespace(child_models=lambda: [volume])
+        self.calls.append(SimpleNamespace(session=session, store=store, name=name, kwargs=kwargs, volume=volume))
+        return [model], ""
+
+
+def _load(tool_module, monkeypatch, store, level):
+    reader = RecordingReader()
+    imported = []
+    models = []
+    artiax = SimpleNamespace(import_tomogram=lambda volume: imported.append(volume) or SimpleNamespace())
+    session = SimpleNamespace(ArtiaX=artiax, models=SimpleNamespace(add=lambda values: models.extend(values)))
+    tool = tool_module.CopickTool.__new__(tool_module.CopickTool)
+    tool.session = session
+    tool.settings = SimpleNamespace(zarr_level=level)
+    tool.active_volume = None
+    monkeypatch.setattr(tool_module, "open_ome_zarr_from_store", reader)
+    tomogram = Tomogram(store)
+
+    tool.load_tomo(tomogram)
+    return tool, tomogram, reader.calls[0], imported, models
+
+
+@pytest.mark.parametrize(
+    ("zarr_format", "paths"),
+    [
+        (2, ("0", "1")),
+        (2, ("s0", "preview")),
+        (3, ("0", "1")),
+        (3, ("s0", "preview")),
+    ],
+)
+@pytest.mark.parametrize("level", [0, 1, 2])
+def test_tomogram_handoff_is_metadata_label_agnostic_and_read_only(
+    tool_module, monkeypatch, tmp_path, zarr_format, paths, level
+):
+    path = tmp_path / f"format-{zarr_format}-{paths[0]}-{level}.zarr"
+    store, expected = write_ome_image(path, zarr_format=zarr_format, paths=paths)
+    before = snapshot(path)
+
+    tool, tomogram, call, imported, models = _load(tool_module, monkeypatch, store, level)
+
+    assert tomogram.zarr_calls == 1
+    assert call.store is store
+    assert call.kwargs == {"initial_step": (2**level, 2**level, 2**level)}
+    assert call.volume.declared_path == paths[0]
+    np.testing.assert_array_equal(call.volume.decoded, expected[0])
+    assert imported == models == [call.volume]
+    assert tool.active_volume.copick_tomo is tomogram
+    assert snapshot(path) == before
+
+
+@pytest.mark.parametrize(
+    "array_options",
+    [
+        {"chunks": (2, 3, 4), "compressors": (GzipCodec(level=2),)},
+        {
+            "chunks": (1, 2, 2),
+            "shards": (2, 4, 4),
+            "filters": (TransposeCodec(order=(2, 1, 0)),),
+            "compressors": (ZstdCodec(level=3),),
+        },
+    ],
+    ids=["alternate-chunks-gzip", "multiple-shards-transpose-zstd"],
+)
+def test_supported_noncanonical_v3_layout_is_passed_without_application_policy(
+    tool_module, monkeypatch, tmp_path, array_options
+):
+    path = tmp_path / "noncanonical.zarr"
+    store, expected = write_ome_image(
+        path,
+        zarr_format=3,
+        paths=("fine", "coarse"),
+        array_options=array_options,
+    )
+    before = snapshot(path)
+
+    _tool, _tomogram, call, _imported, _models = _load(tool_module, monkeypatch, store, 0)
+
+    assert call.volume.declared_path == "fine"
+    np.testing.assert_array_equal(call.volume.decoded, expected[0])
+    assert snapshot(path) == before


### PR DESCRIPTION
## Summary

- add small independent OME-Zarr 0.4/v2 and 0.5/v3 stores
- cover numeric and nonnumeric metadata paths without adding application-side metadata parsing
- verify 0, 1, and 2 resolution choices are passed as 1x, 2x, and 4x initial steps
- construct alternate-chunk/codec and multi-shard v3 fixtures for the application handoff seam
- verify tomogram and single-/multilabel segmentation model wiring and read-only source behavior
- run the same behavior matrix at Zarr 3.1.6 and the maintained 3.3.0 endpoint

The portable `RecordingReader` seam proves store identity, exactly one `.zarr()` call, resolution-to-step mapping, metadata-path reporting, argument forwarding, and byte-level read-only behavior. It does not claim to prove that ChimeraX-OME-Zarr natively opens every constructed layout; that remains a native reader/ChimeraX gate.

## Stack

Layer 3 of 4. Targets `uermel/zarr-v3-x1-alpha-stack`; the next layer is `uermel/zarr-v3-x4-docs-release`.

## Validation

- 24 passed, 1 native ChimeraX smoke deselected at Zarr 3.1.6
- 24 passed, 1 native ChimeraX smoke deselected at Zarr 3.3.0
- no source store keys or bytes change during the read-only handoff

Part of #88
Part of #85
