### PR TITLE
docs: document the v2 alpha migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,51 @@ S3/SSH/SMB storage, or the [CZ cryoET Data Portal](https://cryoetdataportal.czsc
 Picking and 3D visualization are powered by [ArtiaX](https://github.com/FrangakisLab/ArtiaX);
 volumes stream as multiscale OME-Zarr.
 
-## Installation
+## 2.0 alpha installation
 
-Install from the ChimeraX Toolshed: **Tools → More Tools…**, search for **copick**, click
-**Install**, and restart ChimeraX if prompted.
+The `v2.0` line is currently an alpha and is not published to the public ChimeraX Toolshed. It requires ChimeraX
+Daily 1.13 from 2026-08-17 or newer (Core `>=1.13.dev202608172052`) with embedded Python 3.14.
 
-Requires ChimeraX ≥ 1.7. [ArtiaX](https://github.com/FrangakisLab/ArtiaX),
-[ChimeraX-OME-Zarr](https://github.com/uermel/chimerax-ome-zarr), and
-[copick](https://copick.github.io/copick/) are pulled in automatically.
+The initial integration stack is deliberately fixed to:
+
+- `copick==2.0.0a1`;
+- `copick-shared-ui==2.0.0a1`;
+- `ChimeraX-OME-Zarr==1.0.0a1`; and
+- Zarr 3.1.6 for the minimum-stack run, plus Zarr 3.3.0 as the maintained endpoint.
+
+Download `chimerax_ome_zarr-1.0.0a1-py3-none-any.whl` from the
+[ChimeraX-OME-Zarr v1.0.0-alpha.1 release](https://github.com/uermel/chimerax-ome-zarr/releases/tag/v1.0.0-alpha.1)
+and verify its SHA-256 is
+`fd9f0c49505237d200c65afafb24a088ee1f7eb8f8ab29e84991a358354684b0`. Download the selected
+`2.0.0-alpha.N` chimerax-copick wheel and its `.sha256` file from the matching
+[GitHub prerelease](https://github.com/copick/chimerax-copick/releases), then verify that checksum as well.
+
+In a clean ChimeraX Daily profile, install the exact Python alphas and then the two bundle wheels:
+
+```text
+devel pip install "copick[all]==2.0.0a1" "copick-shared-ui==2.0.0a1" "zarr==3.1.6"
+toolshed install /absolute/path/chimerax_ome_zarr-1.0.0a1-py3-none-any.whl
+toolshed install /absolute/path/ChimeraX_copick-2.0.0aN-py3-none-any.whl
+```
+
+The shared-UI PyPI wheel SHA-256 for this stack is
+`c56d06ee53cffc7cda56a916d480793198e2311b099e7965c132ea27e43f6515`. See the
+[alpha release runbook](docs/release-alpha.md) for the build, evidence, and rollback procedure. Do not substitute
+an unqualified install command for these alpha instructions.
+
+## Storage compatibility
+
+ChimeraX-copick 2.0 reads existing OME-Zarr 0.4 / Zarr v2 projects and OME-Zarr 0.5 / Zarr v3 projects. Newly
+created or rebuilt volume stores use OME-Zarr 0.5 / Zarr v3 through copick 2.0; opening a legacy project does not
+convert or rewrite its existing stores. Pyramid arrays are selected from OME metadata, so their paths do not need
+to be numeric. Chunk sizes, shard grids, key encodings, and codecs are input properties interpreted by
+ChimeraX-OME-Zarr, not fixed application requirements.
 
 To create or import projects from the command line (below), also install the copick CLI in
 your terminal environment:
 
 ```shell
-pip install "copick[all]"
+pip install --pre "copick[all]==2.0.0a1"
 ```
 
 ## Quick start

--- a/TOOLSHED.md
+++ b/TOOLSHED.md
@@ -35,21 +35,25 @@ OME-Zarr so even large tomograms open quickly.
 
 ### Installation
 
-Install from the ChimeraX Toolshed:
+Stable chimerax-copick 2.0 will be installed from the ChimeraX Toolshed:
 
 1. In ChimeraX, open **Tools → More Tools…**
 2. Search for **copick** and click **Install**.
 3. Restart ChimeraX if prompted.
 
-ChimeraX-copick requires ChimeraX ≥ 1.7 and pulls in
+The 2.0 release requires ChimeraX Daily 1.13 / Python 3.14 during alpha qualification and pulls in compatible
 [ArtiaX](https://github.com/FrangakisLab/ArtiaX),
 [ChimeraX-OME-Zarr](https://github.com/uermel/chimerax-ome-zarr), and
 [copick](https://copick.github.io/copick/) automatically.
 
+The `2.0.0-alpha.N` bundles are distributed only as checksum-protected GitHub prerelease wheels; they are not
+submitted to the public Toolshed. Alpha testers should follow the repository README for the exact published
+copick, copick-shared-ui, and ChimeraX-OME-Zarr versions.
+
 To create or import projects from the command line (see the examples below), also
 install the copick CLI in your terminal environment:
 
-    pip install "copick[all]"
+    pip install --pre "copick[all]==2.0.0a1"
 
 The `all` extra includes the fsspec backends copick is tested against
 (`local`, `s3`, `smb`, `ssh`). Use `pip>=25.2` or [`uv pip`](https://docs.astral.sh/uv/pip/).
@@ -95,7 +99,9 @@ Even faster, you can create *and* load a portal config without leaving ChimeraX:
 #### Option B — Start from your own MRC tomograms
 
 This creates a local project and imports `.mrc` reconstructions into it. Each tomogram
-is converted to multiscale OME-Zarr so it streams efficiently in the viewer.
+is converted to OME-Zarr 0.5 / Zarr v3 so it streams efficiently in the viewer. Existing OME-Zarr 0.4 / Zarr v2
+projects remain readable and are not rewritten when opened. Resolution arrays are discovered from OME metadata;
+their labels, chunks, shards, keys, and codecs are not assumed by ChimeraX-copick.
 
 In a terminal:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -7,6 +7,11 @@
 
 ## Installation
 
+!!! warning "2.0 alpha"
+    The 2.0 alpha requires ChimeraX Daily 1.13 / Python 3.14 and exact prerelease dependencies. It is installed
+    from checksum-verified GitHub wheels, not from the public Toolshed. Follow the
+    [alpha installation instructions](README.md#20-alpha-installation) while the ecosystem migration is in alpha.
+
 ### 1. Download ChimeraX
 
 Download and install ChimeraX from the [official website](https://www.cgl.ucsf.edu/chimerax/){ target="_blank" }
@@ -17,6 +22,9 @@ Download and install ChimeraX from the [official website](https://www.cgl.ucsf.e
 2. Go to **Tools > More Tools...** to open the toolshed
 3. Search for `copick` in the search bar
 4. Download and install the copick plugin
+
+The Toolshed steps apply to stable releases. For `2.0.0-alpha.N`, install the exact reader and chimerax-copick
+wheels described above.
 
 <!-- Screenshot: ChimeraX toolshed with "copick" search results -->
 
@@ -193,6 +201,10 @@ A table showing all currently defined pickable objects:
 ---
 
 ## 3. Opening a Tomogram
+
+Both legacy OME-Zarr 0.4 / Zarr v2 projects and OME-Zarr 0.5 / Zarr v3 projects open through the same controls.
+Resolution levels come from OME metadata, so projects may use paths such as `s0` and `preview` instead of numeric
+array names. Opening a legacy project does not convert or rewrite its stored volumes.
 
 === "From the Gallery View"
 

--- a/src/docs/user/commands/copick_open_run.html
+++ b/src/docs/user/commands/copick_open_run.html
@@ -30,7 +30,8 @@
         <tr><td><b>zarr_level</b></td>
           <td>Resolution pyramid level to display initially: <b>0</b> = full, <b>1</b> = 2&times;,
             <b>2</b> = 4&times; downsampled. Defaults to the value configured in the table settings.
-            Other levels are still available via the volume step controls after loading.</td></tr>
+            Other levels are still available via the volume step controls after loading. These are zero-based
+            resolution choices, not literal array names; the actual paths are read from OME metadata.</td></tr>
       </tbody>
     </table>
 

--- a/src/docs/user/copick_index.html
+++ b/src/docs/user/copick_index.html
@@ -28,6 +28,8 @@
       <a href="https://copick.github.io/copick/">copick</a> data model to browse runs, load
       tomograms, and view/edit picks, meshes and segmentations, rendering them through
       <a href="help:user/tools/artiax.html">ArtiaX</a>.</p>
+    <p>Version 2.0 requires ChimeraX Daily 1.13 with Python 3.14 during alpha testing and supports both legacy
+      OME-Zarr 0.4 / Zarr v2 and OME-Zarr 0.5 / Zarr v3 volume stores.</p>
     <p>The user interface is described in the <b>Tools</b> section. All commands are prefixed
       with "<strong>copick</strong>". Picks, meshes and segmentations are addressed by their
       <a href="general/copick_uris.html">copick&nbsp;URI</a>.</p>

--- a/src/docs/user/tools/copick.html
+++ b/src/docs/user/tools/copick.html
@@ -23,6 +23,14 @@
     create a new one with <a href="../commands/copick_new.html"><b>copick new</b></a>.
     </p>
 
+    <h4>Storage compatibility</h4>
+    <p>
+    Copick 2.0 projects may contain OME-Zarr 0.4 / Zarr v2 images or OME-Zarr 0.5 / Zarr v3 images. Both are
+    displayed through ChimeraX-OME-Zarr without converting the source. Newly created or rebuilt volume stores use
+    OME-Zarr 0.5 / Zarr v3. Resolution paths, chunks, shards, key encodings and codecs are read from metadata and
+    the store rather than assumed by this tool.
+    </p>
+
     <h4>Layout</h4>
     <ul>
       <li><b>Gallery / Tree</b> &ndash; browse runs. Double-clicking a tomogram opens it (see


### PR DESCRIPTION
## Summary

- document the exact initial copick, shared UI, reader, ChimeraX, Python, and Zarr alpha stack
- provide checksum-first GitHub wheel installation instead of an unqualified install path
- state that alpha bundles remain off the public ChimeraX Toolshed
- document legacy OME-Zarr 0.4/v2 readability and new OME-Zarr 0.5/v3 writes
- explain metadata-defined pyramid paths and layout-agnostic chunk/shard/key/codec handling
- update README, Toolshed copy, tutorial, and embedded ChimeraX help

Release Please will generate the alpha changelog entry when its release PR is created. Stable floor replacement, ecosystem promotion, and Toolshed submission remain gated on every published alpha passing together.

## Stack

Layer 4 of 4. GitHub retains `uermel/zarr-v3-x3-backend-gates` as this PR's base because the PR belongs to a stack;
that branch is now commit-identical to `uermel/zarr-v3-x2-volume-parity`. The former backend-smoke content from #94
was withdrawn and removed.

## Validation

- complete behavior suite passes at Zarr 3.1.6 and 3.3.0
- a ChimeraX Daily 1.13 build emits `Requires-Python: >=3.14` and passes `inspect_bundle.py`
- source, tests, and scripts compile
- documentation does not claim native backend or published-candidate results that have not run

Part of #90
Part of #85
